### PR TITLE
log tcp socket reset and reconnect errors versus kill hsd

### DIFF
--- a/lib/stratum.js
+++ b/lib/stratum.js
@@ -86,7 +86,13 @@ class Stratum extends EventEmitter {
   _init() {
     this.server.on("connection", socket => {
       this.handleSocket(socket);
+      socket.on('error',socketErr=>{
+        this.logger.info('stratum caught socket error %s',socketErr);
+      })
     });
+    this.server.on('error',socketErr=>{
+      this.logger.info('stratum caught socket error %s',socketErr);
+    })
 
     this.node.on("connect", async () => {
       try {
@@ -184,7 +190,7 @@ class Stratum extends EventEmitter {
     const conn = new Connection(this, socket);
 
     conn.on("error", err => {
-      this.emit("error", err);
+      this.logger.info("stratum client conn error",err);
     });
 
     conn.on("close", () => {
@@ -554,7 +560,7 @@ class Stratum extends EventEmitter {
     //difficulty+100 < conn.difficulty - 1
     //vs correct: if(difficulty < conn.difficulty - 1)
     
-    if (difficulty+100 < conn.difficulty - 1) {
+    if (difficulty+10000 < conn.difficulty - 1) {
       //NOTE: difficulty is always returning 0!?
       this.logger.debug(
         "Client submitted a low share of %d, hash=%s, ban=%d (%s).",


### PR DESCRIPTION
commit message says 99% of it.
I also added a couple of extra zeroes to that difficulty testing stuff for now. I had an issue sometimes where first time i spun up miner i'd get zero difficulty bans straight away without those zeroes ha. Will be solved by the pool difficulty fixes anyway.